### PR TITLE
Fix Windows dll symbol export for Unity use

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,11 +5,23 @@ package(default_visibility = ["//visibility:public"])
 cc_shared_library(
     name = "assignment",
     deps = ["//assignment:assignment_plugin"],
+    additional_linker_inputs = select({
+        "@platforms//os:windows": ["//assignment:assignment.def"],
+        "//conditions:default": [],
+    }),
+    win_def_file = select({
+        "@platforms//os:windows": "//assignment:assignment.def",
+        "//conditions:default": None,
+    }),
 )
 
 cc_shared_library(
     name = "example",
     deps = ["//example:example_plugin"],
+    features = select({
+        "@platforms//os:windows": ["windows_export_all_symbols"],
+        "//conditions:default": [],
+    }),
 )
 
 pkg_tar(

--- a/assignment/BUILD.bazel
+++ b/assignment/BUILD.bazel
@@ -1,5 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
+exports_files(["assignment.def"])
+
 cc_library(
     name = "assignment",
     srcs = ["assignment.cc"],

--- a/assignment/assignment.def
+++ b/assignment/assignment.def
@@ -1,0 +1,4 @@
+EXPORTS
+    Assignment_CoverAssignment_Assign
+    Assignment_EvenAssignment_Assign
+    Assignment_WeightedEvenAssignment_Assign 

--- a/assignment/assignment.def
+++ b/assignment/assignment.def
@@ -1,4 +1,4 @@
 EXPORTS
     Assignment_CoverAssignment_Assign
     Assignment_EvenAssignment_Assign
-    Assignment_WeightedEvenAssignment_Assign 
+    Assignment_WeightedEvenAssignment_Assign


### PR DESCRIPTION
## why? 
When loading the assignment plugin DLL in Unity on Windows, i encountered an `EntryPointNotFoundException` error:

```
EntryPointNotFoundException: Assignment_EvenAssignment_Assign assembly:<unknown assembly> type:<unknown type> member:(null)
```

## how fixed?

This occurred because C++ functions are name-mangled by default on Windows (thanks bill)

So this pr implements a separate windows dll export mechanism using a def file

The alternative approach of using `__declspec(dllexport)` with the `windows_export_all_symbols` feature I tried but resulted in a "library limit of 65535 objects exceeded" error due to the large number of dependencies.

## what all change?

1. Fixed an incorrect path in the main BUILD.bazel file:
   - Changed `//sassignment:assignment_plugin` to `//assignment:assignment_plugin`

2. Created a module definition (DEF) file for Windows:
   - Added `assignment.def` that explicitly lists the exported function names
   - This ensures the function names are exported exactly as Unity expects them

3. Updated the Bazel build configuration:
   - Added `win_def_file` and `additional_linker_inputs` parameters to the cc_shared_library rule
   - Used Bazel's platform-specific select() to apply these only on Windows


